### PR TITLE
Use env for credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ Command Line Interface (CLI) - Can be implemented in GUI or Web-based interfaces
 
 - Sentiment Analysis Model: [Transformers documentation](https://huggingface.co/distilbert-base-uncased-finetuned-sst-2-english)
 
+### Required Environment Variables
+
+Set the following variables before running the scrapers:
+
+- `TWITTER_USERNAME` – username or email used for login
+- `TWITTER_PASSWORD` – corresponding password
+
+If these variables are missing, the Twitter and Facebook scrapers raise a `ValueError`.
+
 ## Testing & Quality
 
 Run `flake8` followed by `pytest` before committing changes:

--- a/facebookscraper.py
+++ b/facebookscraper.py
@@ -1,20 +1,24 @@
 from playwright.sync_api import sync_playwright
 from bs4 import BeautifulSoup
 from urllib.parse import quote
+import os
 import time
 import json
-from urllib.parse import quote
 
 
 def facebook(search, stored, no_post):
+    username = os.getenv("TWITTER_USERNAME")
+    password = os.getenv("TWITTER_PASSWORD")
+    if not username or not password:
+        raise ValueError("Twitter credentials not provided")
     starting_url = 'https://www.facebook.com/'
     with sync_playwright() as p:
         browser = p.chromium.launch()
         page = browser.new_page()
         page.goto(starting_url)
         page.wait_for_selector('input[name="email"]')
-        page.fill('input[name="email"]', 'kh708841@gmail.com')
-        page.fill('input[name="pass"]', 'C++program@123')
+        page.fill('input[name="email"]', username)
+        page.fill('input[name="pass"]', password)
         page.click('button[name="login"]')
         page.wait_for_load_state("networkidle")
         search = quote(search)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,18 @@
+import pytest
+
+from twitterscraper import twitter
+from facebookscraper import facebook
+
+
+def test_twitter_missing_env(monkeypatch):
+    monkeypatch.delenv("TWITTER_USERNAME", raising=False)
+    monkeypatch.delenv("TWITTER_PASSWORD", raising=False)
+    with pytest.raises(ValueError):
+        twitter("query", [], 1)
+
+
+def test_facebook_missing_env(monkeypatch):
+    monkeypatch.delenv("TWITTER_USERNAME", raising=False)
+    monkeypatch.delenv("TWITTER_PASSWORD", raising=False)
+    with pytest.raises(ValueError):
+        facebook("query", [], 1)

--- a/twitterscraper.py
+++ b/twitterscraper.py
@@ -1,13 +1,17 @@
 from playwright.sync_api import sync_playwright
 from bs4 import BeautifulSoup
 from urllib.parse import quote
+import os
 import time
 import json
-from urllib.parse import quote
 import threading
 
 def twitter(search, stored, no_post):
     search = quote(search)
+    username = os.getenv("TWITTER_USERNAME")
+    password = os.getenv("TWITTER_PASSWORD")
+    if not username or not password:
+        raise ValueError("Twitter credentials not provided")
     login_url = "https://twitter.com/i/flow/login?input_flow_data=%7B%22requested_variant%22%3A%22eyJsYW5nIjoiZW4ifQ%3D%3D%22%7D"
 
     url = f"https://twitter.com/search?q={search}%20lang%3Aen%20until%3A2023-11-30%20since%3A2023-07-01%20-filter%3Alinks&src=recent_search_click&f=live"
@@ -19,18 +23,18 @@ def twitter(search, stored, no_post):
         page = p.chromium.launch().new_page()
         page.goto(login_url)
         page.wait_for_load_state("networkidle")
-        page.fill("input[name='text']", "kh708841@gmail.com")
+        page.fill("input[name='text']", username)
         page.keyboard.press("Enter")
         page.wait_for_load_state("networkidle")
         try:
-            page.fill('input[name="text"]', "@john85465")
+            page.fill('input[name="text"]', username)
             page.keyboard.press("Enter")
             page.wait_for_load_state("networkidle")
-            page.fill("input[name='password']", "C++program@123")
+            page.fill("input[name='password']", password)
             page.keyboard.press("Enter")
             page.wait_for_load_state("networkidle")
         except Exception as e:
-            page.fill("input[name='password']", "C++program@123")
+            page.fill("input[name='password']", password)
             page.keyboard.press("Enter")
             page.wait_for_load_state("networkidle")
 
@@ -54,7 +58,7 @@ def twitter(search, stored, no_post):
                 continue
         return stored
 
+# Example usage:
 # stored = []
-# search = "tcs"
-# twitter(search, stored)
+# twitter("tcs", stored, 5)
 # print(stored)


### PR DESCRIPTION
## Summary
- replace hard-coded Twitter credentials with environment variables
- document required `TWITTER_USERNAME` and `TWITTER_PASSWORD`
- add tests checking credentials presence

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68534774f1808328b4ab0fbcd942da36