### PR TITLE
Add project-wide .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+
+# Environment files
+.env
+.env.*
+
+# Databases
+*.db
+*.sqlite*
+*.db-journal
+
+# IDE/Editor directories
+.vscode/
+.idea/
+
+# Jupyter
+.ipynb_checkpoints/
+
+# Misc
+.DS_Store
+*.egg-info/
+dist/
+build/

--- a/README.md
+++ b/README.md
@@ -97,3 +97,8 @@ Run `flake8` followed by `pytest` before committing changes:
 flake8
 pytest
 ```
+
+## Development Setup
+
+This repository includes a `.gitignore` file that excludes typical temporary files such as `__pycache__/`, `*.db`, and `.env` entries. Ensure your local environment respects these rules to keep commits clean.
+


### PR DESCRIPTION
## Summary
- add `.gitignore` for common Python/IDE artifacts
- document `.gitignore` in new *Development Setup* section of README

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685354c6c3f083288dcb18fdbe62b3ad