### PR TITLE
Update store_raw to append data

### DIFF
--- a/database/storage.py
+++ b/database/storage.py
@@ -12,9 +12,9 @@ def _connect(db_path: str = DB_PATH):
 def store_raw(table: str, rows: Iterable[Tuple[str, str]]) -> None:
     with _connect() as conn:
         cur = conn.cursor()
-        cur.execute(f"DROP TABLE IF EXISTS {table}")
         cur.execute(
-            f"CREATE TABLE {table} (id INTEGER PRIMARY KEY, source TEXT, text TEXT)"
+            f"CREATE TABLE IF NOT EXISTS {table} ("
+            "id INTEGER PRIMARY KEY, source TEXT, text TEXT)"
         )
         cur.executemany(f"INSERT INTO {table} (source, text) VALUES (?, ?)", rows)
         conn.commit()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,20 @@
+import importlib
+
+
+def test_store_raw_appends(monkeypatch, tmp_path):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("SOCIAL_DB_PATH", str(db_file))
+    import database.storage as storage
+    importlib.reload(storage)
+
+    storage.store_raw("posts", [("Twitter", "hello")])
+    storage.store_raw("posts", [("Twitter", "world")])
+
+    with storage._connect(str(db_file)) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT source, text FROM posts")
+        rows = cur.fetchall()
+    assert rows == [
+        ("Twitter", "hello"),
+        ("Twitter", "world"),
+    ]


### PR DESCRIPTION
## Summary
- ensure store_raw uses `CREATE TABLE IF NOT EXISTS` instead of dropping the table
- add a test confirming repeated calls append records

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685354c753e883289b1e23150dd94202