### PR TITLE
Use env vars for email credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,10 @@ Set the following variables before running the scrapers:
 
 - `TWITTER_USERNAME` – username or email used for login
 - `TWITTER_PASSWORD` – corresponding password
+- `EMAIL_SENDER` – address used to send notification emails
+- `EMAIL_PASSWORD` – password for the sending account
 
-If these variables are missing, the Twitter and Facebook scrapers raise a `ValueError`.
+If these variables are missing, the Twitter and Facebook scrapers and the email sender raise a `ValueError`.
 
 ## Testing & Quality
 

--- a/email_sender.py
+++ b/email_sender.py
@@ -1,3 +1,4 @@
+import os
 import smtplib
 import ssl
 from email.message import EmailMessage
@@ -5,9 +6,11 @@ from email.message import EmailMessage
 def send_email(rows, email_receiver, search):
 
 
-    # Define email sender and receiver
-    email_sender = ''
-    email_password = ''
+    # Define email sender and password from environment
+    email_sender = os.getenv("EMAIL_SENDER")
+    email_password = os.getenv("EMAIL_PASSWORD")
+    if not email_sender or not email_password:
+        raise ValueError("Email credentials not provided")
 
     # Set the subject and body of the email
     subject = 'Sentiment Analysis Report For Your Brand'

--- a/tests/test_email_sender.py
+++ b/tests/test_email_sender.py
@@ -1,0 +1,29 @@
+import email_sender
+
+
+class DummySMTP:
+    def __init__(self, *args, **kwargs):
+        self.login_args = None
+        self.sent_from = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def login(self, user, password):
+        self.login_args = (user, password)
+
+    def sendmail(self, from_addr, to_addr, msg):
+        self.sent_from = from_addr
+
+
+def test_send_email_uses_env(monkeypatch):
+    smtp_instance = DummySMTP()
+    monkeypatch.setenv("EMAIL_SENDER", "me@example.com")
+    monkeypatch.setenv("EMAIL_PASSWORD", "secret")
+    monkeypatch.setattr(email_sender.smtplib, "SMTP_SSL", lambda *a, **k: smtp_instance)
+    email_sender.send_email([0, 0, 0, 0, 0, 0, 0, 0, 0, 0], "you@example.com", "brand")
+    assert smtp_instance.login_args == ("me@example.com", "secret")
+    assert smtp_instance.sent_from == "me@example.com"


### PR DESCRIPTION
## Summary
- read email credentials from `EMAIL_SENDER` and `EMAIL_PASSWORD`
- document new environment variables in README
- test email sender respects the environment using monkeypatch

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68535e6d6058832886eb0d198e35349b