### PR TITLE
Ensure store_raw appends data and add tests

### DIFF
--- a/database/storage.py
+++ b/database/storage.py
@@ -10,13 +10,20 @@ def _connect(db_path: str = DB_PATH):
 
 
 def store_raw(table: str, rows: Iterable[Tuple[str, str]]) -> None:
+    """Persist raw scraped posts.
+
+    The table is created on first use and subsequent calls simply
+    append new records without altering existing rows.
+    """
     with _connect() as conn:
         cur = conn.cursor()
         cur.execute(
             f"CREATE TABLE IF NOT EXISTS {table} ("
             "id INTEGER PRIMARY KEY, source TEXT, text TEXT)"
         )
-        cur.executemany(f"INSERT INTO {table} (source, text) VALUES (?, ?)", rows)
+        cur.executemany(
+            f"INSERT INTO {table} (source, text) VALUES (?, ?)", rows
+        )
         conn.commit()
 
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -18,3 +18,23 @@ def test_store_raw_appends(monkeypatch, tmp_path):
         ("Twitter", "hello"),
         ("Twitter", "world"),
     ]
+
+
+def test_store_raw_multiple_batches(monkeypatch, tmp_path):
+    """Ensure repeated calls with multiple rows append properly."""
+    db_file = tmp_path / "batch.db"
+    monkeypatch.setenv("SOCIAL_DB_PATH", str(db_file))
+    import database.storage as storage
+    importlib.reload(storage)
+
+    batch_one = [("Facebook", "foo"), ("Facebook", "bar")]
+    batch_two = [("Reddit", "baz"), ("Reddit", "qux")]
+
+    storage.store_raw("posts", batch_one)
+    storage.store_raw("posts", batch_two)
+
+    with storage._connect(str(db_file)) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT source, text FROM posts")
+        rows = cur.fetchall()
+    assert rows == batch_one + batch_two


### PR DESCRIPTION
## Summary
- document that `store_raw` appends records instead of overwriting
- test multiple batches of `store_raw` calls

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68535e6e5f4c8328897868ad82b965a8