### PR TITLE
Add Requesty summarisation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,16 @@ Set the following variables before running the scrapers:
 - `TWITTER_PASSWORD` – corresponding password
 - `EMAIL_SENDER` – address used to send notification emails
 - `EMAIL_PASSWORD` – password for the sending account
+- `REQUESTY_BASE_URL` – base URL for the Requesty router (optional)
+- `REQUESTY_API_KEY` – API key for Requesty
 
 If these variables are missing, the Twitter and Facebook scrapers and the email sender raise a `ValueError`.
+
+### LLM Summarisation
+
+When `REQUESTY_BASE_URL` and `REQUESTY_API_KEY` are set, the orchestrator can call
+`analytics.llm_analysis.generate_summary` to produce a short summary of the scraped
+posts. The returned dataframe includes this summary under `df.attrs["summary"]`.
 
 ## Testing & Quality
 

--- a/analytics/llm_analysis.py
+++ b/analytics/llm_analysis.py
@@ -1,0 +1,25 @@
+"""LLM powered text summarisation via Requesty."""
+from __future__ import annotations
+
+import os
+
+from pydantic_ai import Agent
+from pydantic_ai.providers.openai import OpenAIProvider
+
+
+MODEL_NAME = "openai:gpt-3.5-turbo"
+
+
+async def generate_summary(text: str) -> str:
+    """Return a short summary for ``text`` using the Requesty router."""
+    base_url = os.getenv("REQUESTY_BASE_URL")
+    api_key = os.getenv("REQUESTY_API_KEY")
+    if not base_url or not api_key:
+        raise ValueError("Requesty configuration not provided")
+
+    provider = OpenAIProvider(base_url=base_url, api_key=api_key)
+    agent = Agent(MODEL_NAME, provider=provider)
+    result = await agent.run(
+        f"Summarise the following text in a short paragraph:\n{text}"
+    )
+    return str(result.output)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@
 pandas
 playwright
 beautifulsoup4
+pydantic_ai
+openai
 
 # Development and testing
 flake8

--- a/tests/test_llm_analysis.py
+++ b/tests/test_llm_analysis.py
@@ -1,0 +1,46 @@
+from types import SimpleNamespace
+
+import pytest
+
+from analytics import llm_analysis
+import pydantic_ai.providers.openai as openai_provider
+from orchestrator.core import ScraperOrchestrator
+
+
+class DummyClient:
+    def __init__(self, *args, **kwargs):
+        self.chat = SimpleNamespace(
+            completions=SimpleNamespace(create=self.create)
+        )
+
+    async def create(self, *args, **kwargs):
+        msg = SimpleNamespace(content="summary", tool_calls=None, reasoning_content=None)
+        choice = SimpleNamespace(message=msg, logprobs=None)
+        return SimpleNamespace(created=0, choices=[choice], usage=None, model="gpt", id="1")
+
+
+@pytest.mark.asyncio
+async def test_generate_summary(monkeypatch):
+    monkeypatch.setenv("REQUESTY_BASE_URL", "http://test")
+    monkeypatch.setenv("REQUESTY_API_KEY", "secret")
+    monkeypatch.setattr(openai_provider, "AsyncOpenAI", DummyClient)
+
+    result = await llm_analysis.generate_summary("hello world")
+    assert result == "summary"
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_uses_summary(monkeypatch):
+    orch = ScraperOrchestrator()
+    orch.agents = {"dummy": lambda q, limit: [("x", "text1"), ("x", "text2")]}  # type: ignore
+
+    async def dummy_summary(text: str) -> str:
+        return "sum"
+
+    df = await orch.scrape_and_analyze(
+        "query",
+        1,
+        lambda df: df,
+        summarize=dummy_summary,
+    )
+    assert df.attrs["summary"] == "sum"


### PR DESCRIPTION
## Summary
- create `analytics.llm_analysis` using pydantic_ai and Requesty router
- expose `generate_summary()` and integrate optional summarisation in orchestrator
- document new environment variables and feature in README
- add dependency requirements
- add tests for Requesty summarisation

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68536059551c8328b037ddb473cb57a0